### PR TITLE
adding ability to disable gurobi

### DIFF
--- a/neural_clbf/controllers/clf_controller.py
+++ b/neural_clbf/controllers/clf_controller.py
@@ -41,7 +41,10 @@ class CLFController(Controller):
             clf_lambda: convergence rate for the CLF
             clf_relaxation_penalty: the penalty for relaxing CLF conditions.
             controller_period: the timestep to use in simulating forward Vdot
-            disable_gurobi: if True, gurobi will not be used
+            disable_gurobi: if True, Gurobi will not be used during evaluation. 
+                Default is train with CVXPYLayers, evaluate with Gurobi; 
+                setting this to true will evaluate with CVXPYLayers instead 
+                (to avoid requiring a Gurobi license)
         """
         super(CLFController, self).__init__(
             dynamics_model=dynamics_model,

--- a/neural_clbf/controllers/neural_clbf_controller.py
+++ b/neural_clbf/controllers/neural_clbf_controller.py
@@ -54,6 +54,7 @@ class NeuralCLBFController(pl.LightningModule, CLFController):
         barrier: bool = True,
         add_nominal: bool = False,
         normalize_V_nominal: bool = False,
+        disable_gurobi: bool = False,
     ):
         """Initialize the controller.
 
@@ -79,6 +80,7 @@ class NeuralCLBFController(pl.LightningModule, CLFController):
                      effectively trains only a CLF.
             add_nominal: if True, add the nominal V
             normalize_V_nominal: if True, normalize V_nominal so that its average is 1
+            disable_gurobi: if True, gurobi will not be used
         """
         super(NeuralCLBFController, self).__init__(
             dynamics_model=dynamics_model,
@@ -87,6 +89,7 @@ class NeuralCLBFController(pl.LightningModule, CLFController):
             clf_lambda=clf_lambda,
             clf_relaxation_penalty=clf_relaxation_penalty,
             controller_period=controller_period,
+            disable_gurobi=disable_gurobi,
         )
         self.save_hyperparameters()
 

--- a/neural_clbf/controllers/neural_clbf_controller.py
+++ b/neural_clbf/controllers/neural_clbf_controller.py
@@ -80,7 +80,10 @@ class NeuralCLBFController(pl.LightningModule, CLFController):
                      effectively trains only a CLF.
             add_nominal: if True, add the nominal V
             normalize_V_nominal: if True, normalize V_nominal so that its average is 1
-            disable_gurobi: if True, gurobi will not be used
+            disable_gurobi: if True, Gurobi will not be used during evaluation. 
+                Default is train with CVXPYLayers, evaluate with Gurobi; 
+                setting this to true will evaluate with CVXPYLayers instead 
+                (to avoid requiring a Gurobi license)
         """
         super(NeuralCLBFController, self).__init__(
             dynamics_model=dynamics_model,

--- a/neural_clbf/training/train_inverted_pendulum.py
+++ b/neural_clbf/training/train_inverted_pendulum.py
@@ -109,6 +109,7 @@ def main(args):
         num_init_epochs=5,
         epochs_per_episode=100,
         barrier=False,
+        disable_gurobi=True,
     )
 
     # Initialize the logger and trainer


### PR DESCRIPTION
this makes it easier to get started with the neural_clbf library as user don't need to go through gurobi's licensing process and cvx is easily swapped in as an alternative