### PR TITLE
Implement Cartpole

### DIFF
--- a/neural_clbf/systems/cartpole.py
+++ b/neural_clbf/systems/cartpole.py
@@ -1,0 +1,253 @@
+"""Define a dymamical system for a cartpole"""
+from typing import Tuple, Optional, List
+
+import math
+import torch
+
+from neural_clbf.systems import ControlAffineSystem
+from neural_clbf.systems.utils import Scenario, ScenarioList
+
+class Cartpole(ControlAffineSystem):
+
+    """
+    Represents a Cartpole.
+
+    The system has state
+
+        x = [pos, vel, theta, theta_dot]
+
+    (pos, vel) are the x-position and velocity of the cart
+    (theta, theta_dot) are the angle, velocity of the pole
+
+    and it has control inputs
+
+        u = [u]
+
+    representing the x-force applied to the cart.
+    """
+    # Number of states and controls
+    N_DIMS = 4
+    N_CONTROLS = 1
+
+    # State indices
+    CART_POS = 0
+    CART_VEL = 1
+    POLE_ANGLE = 2
+    POLE_ANGVEL = 3
+
+    # Control indices
+    U = 0
+
+    def __init__(
+        self,
+        nominal_params: Scenario,
+        dt: float = 0.01,
+        controller_dt: Optional[float] = None,
+        use_linearized_controller: bool = True,
+        scenarios: Optional[ScenarioList] = None,
+    ):
+        # TODO: Make all this configurable through 'params' dict
+        self.gravity = 9.8
+        self.masscart = 1.0
+        self.masspole = 0.1
+        self.total_mass = (self.masspole + self.masscart)
+        self.length = 0.5  # actually half the pole's length
+        self.force_mag = 10.0
+
+        super().__init__(nominal_params, dt, controller_dt, use_linearized_controller, scenarios)
+
+    def validate_params(self, params: Scenario) -> bool:
+        """Check if a given set of parameters is valid
+
+        args:
+            params: a dictionary giving the parameter values for the system.
+                    Requires keys []
+        returns:
+            True if parameters are valid, False otherwise
+        """
+        valid = True
+        # TODO: Implement system parameters
+        return valid
+    
+    @property 
+    def n_dims(self) -> int:
+        return Cartpole.N_DIMS
+
+    @property
+    def angle_dims(self) -> List[int]:
+        return [Cartpole.POLE_ANGLE]
+
+    @property
+    def n_controls(self) -> int:
+        return Cartpole.N_CONTROLS
+
+    @property
+    def state_limits(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Return a tuple (upper, lower) describing the expected range of states for this
+        system
+        """
+        # define upper and lower limits based around the nominal equilibrium input
+        upper_limit = torch.ones(self.n_dims)
+        upper_limit[Cartpole.CART_POS] = 4.8
+        upper_limit[Cartpole.CART_VEL] = 100
+        upper_limit[Cartpole.POLE_ANGLE] = math.pi
+        upper_limit[Cartpole.POLE_ANGVEL] =  100
+
+        lower_limit = -1.0 * upper_limit
+
+        return (upper_limit, lower_limit)
+
+    @property
+    def control_limits(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Return a tuple (upper, lower) describing the range of allowable control
+        limits for this system
+        """
+        # define upper and lower limits based around the nominal equilibrium input
+        upper_limit = torch.tensor([100 * 10.0])
+        lower_limit = -torch.tensor([100 * 10.0])
+
+        return (upper_limit, lower_limit)
+
+    def safe_mask(self, x):
+        """Return the mask of x indicating safe regions for the obstacle task
+
+        args:
+            x: a tensor of (batch_size, self.n_dims) points in the state space
+        returns:
+            a tensor of (batch_size,) booleans indicating whether the corresponding
+            point is in this region.
+        """
+        safe_mask = x.norm(dim=-1) <= 1.0
+
+        return safe_mask
+
+    def unsafe_mask(self, x):
+        """Return the mask of x indicating unsafe regions for the obstacle task
+
+        args:
+            x: a tensor of (batch_size, self.n_dims) points in the state space
+        returns:
+            a tensor of (batch_size,) booleans indicating whether the corresponding
+            point is in this region.
+        """
+        unsafe_mask = x.norm(dim=-1) >= 1.5
+
+        return unsafe_mask
+
+    def goal_mask(self, x):
+        """Return the mask of x indicating points in the goal set
+
+        args:
+            x: a tensor of (batch_size, self.n_dims) points in the state space
+        returns:
+            a tensor of (batch_size,) booleans indicating whether the corresponding
+            point is in this region.
+        """
+        pole_angle = x[..., Cartpole.POLE_ANGLE]
+        pole_angvel = x[..., Cartpole.POLE_ANGVEL]
+        pole_state = torch.stack([pole_angle, pole_angvel], dim=-1)
+        pole_goal = pole_state.norm(dim=-1) <= 0.3
+
+        cart_pos = x[..., Cartpole.CART_POS]
+        cart_vel = x[..., Cartpole.CART_VEL]
+        cart_state = torch.stack([cart_pos, cart_vel], dim=-1)
+        cart_goal = cart_state.norm(dim=-1) <= 0.3
+
+        goal_mask = torch.logical_or(pole_goal, cart_goal)
+        return goal_mask
+
+    def _f(self, x: torch.Tensor, params: Scenario) -> torch.Tensor:
+        """ Calculate the control-independent dynamics of the cartpole """
+        # Unpack state
+        q = x[..., Cartpole.CART_POS] # Cart position
+        qdot = x[..., Cartpole.CART_VEL] # Cart velocity
+        w = x[..., Cartpole.POLE_ANGLE] # Pole angle
+        wdot = x[..., Cartpole.POLE_ANGVEL] # Pole angular velocity
+
+        dot_q = qdot
+        dot_w = wdot
+        # Correct
+        dot_wdot = (
+            (
+                self.gravity * self.total_mass * torch.sin(w) 
+                - self.masspole * self.length * (wdot ** 2 * torch.sin(w) * torch.cos(w))
+            )
+            /
+            (
+                (4/3) * self.length *self.total_mass 
+                - self.masspole * self.length * torch.cos(w) ** 2
+            )
+        )  
+        Ax = dot_wdot
+        # Correct
+        dot_qdot = (
+            (self.masspole * self.length * (wdot ** 2 * torch.sin(w) - torch.cos(w) * Ax))
+            / (self.total_mass)
+        )
+
+        fx = torch.stack([dot_q, dot_qdot, dot_w, dot_wdot], dim=-1)
+        return fx.unsqueeze(-1)
+
+    def _g(self, x: torch.Tensor, params: Scenario) -> torch.Tensor:
+        """ Calculate the control-dependent dynamics of the cartpole """
+        # Unpack state
+        q = x[...,  Cartpole.CART_POS] # Cart position
+        qdot = x[..., Cartpole.CART_VEL] # Cart velocity
+        w = x[..., Cartpole.POLE_ANGLE] # Pole angle
+        wdot = x[..., Cartpole.POLE_ANGVEL] # Pole angular velocity
+
+        dot_q = torch.zeros_like(q)
+        dot_w = torch.zeros_like(q)
+        # Correct
+        dot_wdot = (
+            -torch.cos(w)
+            / 
+            (
+                (4/3) * self.length *self.total_mass 
+                - self.masspole * self.length * torch.cos(w) ** 2
+            )
+        )  
+        Bx = dot_wdot
+        # Correct
+        dot_qdot = (
+            (1 - self.masspole * self.length * torch.cos(w) * Bx)
+            / self.total_mass 
+        )
+        return torch.stack([dot_q, dot_qdot, dot_w, dot_wdot], dim=-1).unsqueeze(-1)
+    
+    def reference_dynamics(self, x: torch.Tensor, u:torch.Tensor) -> torch.Tensor:
+        """ Calculate the reference dynamics of the cartpole 
+        
+        Reference: https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py """
+
+        # Unpack state
+        q = x[..., 0] # Cart position
+        q_dot = x[..., 1] # Cart velocity
+        theta = x[..., 2] # Pole angle
+        theta_dot = x[..., 3] # Pole angular velocity
+        force = u[..., 0]
+        costheta = torch.cos(theta)
+        sintheta = torch.sin(theta)
+
+        temp = (
+            force + self.masspole * self.length * theta_dot**2 * sintheta
+        ) / self.total_mass
+        thetaacc = (self.gravity * sintheta - costheta * temp) / (
+            self.length * (4.0 / 3.0 - self.masspole * costheta**2 / self.total_mass)
+        )
+        xacc = temp - self.masspole * self.length * thetaacc * costheta / self.total_mass
+
+        return torch.stack([q_dot, xacc, theta_dot, thetaacc], dim=-1)
+    
+if __name__ == "__main__":
+    # Sanity check the dynamics
+    nominal_params={}
+    x = torch.randn([32, 4])
+    u = torch.randn([32, 1])
+
+    cartpole = Cartpole(nominal_params)
+    xdot_control_affine = cartpole.closed_loop_dynamics(x, u, nominal_params)
+    xdot_reference = cartpole.reference_dynamics(x, u)
+    assert torch.allclose(xdot_control_affine, xdot_reference)

--- a/neural_clbf/systems/cartpole.py
+++ b/neural_clbf/systems/cartpole.py
@@ -89,9 +89,9 @@ class Cartpole(ControlAffineSystem):
         """
         # define upper and lower limits based around the nominal equilibrium input
         upper_limit = torch.ones(self.n_dims)
-        upper_limit[Cartpole.CART_POS] = 1.0
+        upper_limit[Cartpole.CART_POS] = 4.8
         upper_limit[Cartpole.CART_VEL] = 2.0
-        upper_limit[Cartpole.POLE_ANGLE] = 1.0
+        upper_limit[Cartpole.POLE_ANGLE] = 24 * 2 * math.pi / 360
         upper_limit[Cartpole.POLE_ANGVEL] =  2.0
 
         lower_limit = -1.0 * upper_limit

--- a/neural_clbf/systems/cartpole.py
+++ b/neural_clbf/systems/cartpole.py
@@ -89,10 +89,10 @@ class Cartpole(ControlAffineSystem):
         """
         # define upper and lower limits based around the nominal equilibrium input
         upper_limit = torch.ones(self.n_dims)
-        upper_limit[Cartpole.CART_POS] = 4.8
-        upper_limit[Cartpole.CART_VEL] = 100
-        upper_limit[Cartpole.POLE_ANGLE] = math.pi
-        upper_limit[Cartpole.POLE_ANGVEL] =  100
+        upper_limit[Cartpole.CART_POS] = 1.0
+        upper_limit[Cartpole.CART_VEL] = 2.0
+        upper_limit[Cartpole.POLE_ANGLE] = 1.0
+        upper_limit[Cartpole.POLE_ANGVEL] =  2.0
 
         lower_limit = -1.0 * upper_limit
 

--- a/neural_clbf/training/train_cartpole.py
+++ b/neural_clbf/training/train_cartpole.py
@@ -22,6 +22,18 @@ from neural_clbf.training.utils import current_git_hash
 
 torch.multiprocessing.set_sharing_strategy("file_system")
 
+def maybe_init_wandb(args):
+    if args.track:
+        import wandb
+        run = wandb.init(
+            project=args.wandb_project,
+            group=args.wandb_group,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            name=args.wandb_run_name,
+        )
+        return run
+
 def main(args):
 
     nominal_params = {}
@@ -110,6 +122,8 @@ def main(args):
         disable_gurobi=True,
         barrier=args.barrier,
     )
+
+    maybe_init_wandb(args)
     
     # Initialize the logger and trainer
     logger = pl_loggers.TensorBoardLogger(
@@ -137,9 +151,17 @@ def add_clbf_argparse_args(parser: ArgumentParser):
     parser.add_argument('--n-epochs', type=int, default=51)
     return parser
 
+def add_wandb_argparse_args(parser: ArgumentParser):
+    parser.add_argument('--wandb-entity', type=str, default='dtch1997')
+    parser.add_argument('--wandb-group', type=str, default="default")
+    parser.add_argument('--wandb-project', type=str, default='NeuralCLBF')
+    parser.add_argument('--wandb-run-name', type=str, default='cartpole')
+    return parser
+
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser = pl.Trainer.add_argparse_args(parser)
     parser = add_clbf_argparse_args(parser)
+    parser = add_wandb_argparse_args(parser)
     args = parser.parse_args()
     main(args)

--- a/neural_clbf/training/train_cartpole.py
+++ b/neural_clbf/training/train_cartpole.py
@@ -1,0 +1,145 @@
+from argparse import ArgumentParser
+
+import torch
+import torch.multiprocessing
+import pytorch_lightning as pl
+from pytorch_lightning import loggers as pl_loggers
+import numpy as np
+
+from neural_clbf.systems.cartpole import Cartpole
+from neural_clbf.controllers import NeuralCLBFController
+from neural_clbf.datamodules.episodic_datamodule import (
+    EpisodicDataModule,
+)
+
+from neural_clbf.experiments import (
+    CLFContourExperiment,
+    RolloutStateSpaceExperiment,
+    ExperimentSuite,
+)
+from neural_clbf.training.utils import current_git_hash
+
+
+torch.multiprocessing.set_sharing_strategy("file_system")
+
+def main(args):
+
+    nominal_params = {}
+    simulation_dt = args.dt
+    controller_period = args.controller_dt
+    scenarios = [
+        nominal_params,
+    ]
+
+    dynamics_model = Cartpole(
+        nominal_params,
+        dt=simulation_dt,
+        controller_dt=controller_period,
+        scenarios=scenarios,
+    )
+
+    # Initialize the DataModule
+    initial_conditions = [
+        (-1.0, 1.0), # cart_pos
+        (-4.0, 4.0), # cart_vel
+        (-np.pi / 2, np.pi / 2),  # pole_angle
+        (-1.0, 1.0),  # pole_angvel
+    ]
+
+    data_module = EpisodicDataModule(
+        dynamics_model,
+        initial_conditions,
+        trajectories_per_episode=0,
+        trajectory_length=1,
+        fixed_samples=args.n_fixed_samples,
+        max_points=100000,
+        val_split=0.1,
+        batch_size=args.batch_size,
+        # quotas={"safe": 0.2, "unsafe": 0.2, "goal": 0.4},
+    )
+
+    # TODO: Define the experiment suite
+    # V_contour_experiment, rollout_experiment
+    V_contour_thetas_experiment = CLFContourExperiment(
+        "V_Contour_thetas",
+        domain=[(-1.5, 1.5), (-1.5, 1.5)],
+        n_grid=25,
+        x_axis_index=Cartpole.POLE_ANGLE,
+        y_axis_index=Cartpole.POLE_ANGVEL,
+        x_axis_label="$\\theta$",
+        y_axis_label="$\\dot{\\theta}$",
+    )
+    start_x = torch.Tensor(
+        [
+            [0.5, 0.5, 0.5, 0.5],
+            [-0.2, 1.0, -0.2, 1.0],
+            [0.2, -1.0, 0.2, -1.0],
+            [-0.2, -1.0, -0.2, -1.0],
+        ]
+    )
+    rollout_thetas_experiment = RolloutStateSpaceExperiment(
+        "Rollout_thetas",
+        start_x,
+        Cartpole.CART_POS,
+        "$\\theta$",
+        Cartpole.CART_VEL,
+        "$\\dot{\\theta}$",
+        scenarios=scenarios,
+        n_sims_per_start=1,
+        t_sim=5.0,
+    )
+    experiment_suite = ExperimentSuite([
+        V_contour_thetas_experiment,
+        rollout_thetas_experiment,
+    ])
+
+    # Initialize the controller
+    clbf_controller = NeuralCLBFController(
+        dynamics_model,
+        scenarios,
+        data_module,
+        experiment_suite=experiment_suite,
+        clbf_hidden_layers=2,
+        clbf_hidden_size=64,
+        clf_lambda=1.0,
+        safe_level=1.0,
+        controller_period=controller_period,
+        clf_relaxation_penalty=1e2,
+        num_init_epochs=5,
+        epochs_per_episode=100,
+        disable_gurobi=True,
+        barrier=args.barrier,
+    )
+    
+    # Initialize the logger and trainer
+    logger = pl_loggers.TensorBoardLogger(
+        "logs/cartpole",
+        name=f"commit_{current_git_hash()}",
+    )
+    trainer = pl.Trainer.from_argparse_args(
+        args,
+        logger=logger,
+        reload_dataloaders_every_epoch=True,
+        max_epochs=args.n_epochs,
+    )
+
+    # Train
+    torch.autograd.set_detect_anomaly(True)
+    trainer.fit(clbf_controller)
+
+def add_clbf_argparse_args(parser: ArgumentParser):
+    parser.add_argument('--dt', type=float, default=0.01, help='Simulation timestep')
+    parser.add_argument('--controller_dt', type=float, default=0.05, help='Controller timestep')
+    parser.add_argument('--batch-size', type=int, default=64, help='Batch size')
+    parser.add_argument('--n-fixed-samples', type=int, default=10000, help='Number of fixed samples')
+    parser.add_argument('--barrier', action='store_true', help='Use barrier function')
+    parser.add_argument('-t', '--track', action='store_true', default=False)
+    parser.add_argument('--n-epochs', type=int, default=51)
+    return parser
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser = pl.Trainer.add_argparse_args(parser)
+    parser = add_clbf_argparse_args(parser)
+    args = parser.parse_args()
+    main(args)

--- a/run_train.sh
+++ b/run_train.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for i in {1..20}
+do
+    python neural_clbf/training/train_cartpole.py --n-epochs 50 --track --wandb-group cartpole
+done


### PR DESCRIPTION
Hi there @dawsonc , I've got a mostly functional version of Cartpole which I believe would be a nice addition to this repo, and I would like to request some help with merging it in. 

I have implemented Cartpole following these [equations of motion](https://coneural.org/florian/papers/05_cart_pole.pdf), which are also used by the [OpenAI gym implementation](https://github.com/openai/gym/blob/master/gym/envs/classic_control/cartpole.py). 

After some algebraic manipulation, I have derived the control-affine form of the equations implemented in `neural_clbf/systems/cartpole.py`. Running the file checks that the closed-loop dynamics derived from these equations is identical to the full dynamics for several randomly-sampled states and controls. 

I have implemented an associated training script, however I invariably  get issues with infeasible QPs as follows:
```
$ python neural_clbf/training/train_cartpole.py --n-epochs 1
...
    raise SolverError("Solver scs returned status %s" % status)
diffcp.cone_program.SolverError: Solver scs returned status infeasible
```
I'm struggling to figure out the cause and a bit of advice would be much appreciated. Thanks very much!